### PR TITLE
added ticp as an alias for titanium-code-processor

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
 		"test": "node tests/bin/tests"
 	},
 	"main": "lib/CodeProcessor.js",
-	"bin": "bin/codeprocessor",
+	"bin": {
+    "ticp": "bin/codeprocessor",
+    "titanium-code-processor":"bin/codeprocessor"
+  },
 	"dependencies": {
 		"uglify-js": "1.2.x",
 		"wrench": "1.3.x",


### PR DESCRIPTION
Entering 'titanium-code-processor' is a bit long - ticp is nicer.

Great work.
