### PR TITLE
TIMOB-14638 Allow code processor to wait after processing the results

### DIFF
--- a/commands/analyze.js
+++ b/commands/analyze.js
@@ -130,6 +130,11 @@ exports.config = function (logger, config) {
 				desc: __('The maximum number of cycles to allow before throwing an exception'),
 				hint: __('size'),
 				default: Runtime.options.maxCycles
+			},
+			'wait': {
+				abbr: 'W',
+				desc: __('Process waits on standard input after processing the results'),
+				default: false
 			}
 		}
 	};
@@ -174,6 +179,19 @@ function run(sourceInformation, options, plugins, logger, cli) {
 		setTimeout(function () {
 			CodeProcessor.run(sourceInformation, options, plugins, logger, function () {});
 		}, 0);
+
+		if (true) //TODO: cli.argv['wait']
+		{
+			var stdin = process.stdin;
+			stdin.setRawMode( true );
+			stdin.resume();
+			stdin.setEncoding( 'utf8' );
+
+			// on any data into stdin
+			stdin.on( 'data', function( key ){
+				process.exit();
+			});
+		}
 	});
 }
 

--- a/lib/CodeProcessor.js
+++ b/lib/CodeProcessor.js
@@ -286,6 +286,10 @@ function run(sourceInformation, options, plugins, logger, callback) {
 		Runtime.log('info', 'Generating results');
 		Runtime.fireEvent('projectProcessingEnd', 'Project processing complete');
 		generateResultsPages(options.outputFormat, Runtime.options.resultsPath, Runtime.options.resultsTheme, callback);
+		if (options.outputFormat === 'stream') {
+			var endEvent = JSON.stringify({'projectProcessingEnd':true});
+			console.log('REQ,01000002,' + ('00000000' + endEvent.length.toString(16)).slice(-8) + ',' + endEvent);
+		}
 	} catch(e) {
 		if (e.message === 'Maximum call stack size exceeded') {
 			console.error('node.js maximum call stack size exceeded. Increasing the stack size may allow the project to be fully analyzed');


### PR DESCRIPTION
Forced to wait after processing the results.
Fired an event after it analyzes the projects, so that Studio can kill the process after it reads the data.
