### PR TITLE
fix for id of undefined error

### DIFF
--- a/commands/analyze.js
+++ b/commands/analyze.js
@@ -424,7 +424,7 @@ function validateCLIParameters(logger, config, cli, callback) {
 
 	// Validate the project information
 	ti.validateProjectDir(logger, cli, cli.argv, 'project-dir');
-	ti.validateTiappXml(logger, cli.tiapp);
+	ti.validateTiappXml(logger, config, cli.tiapp);
 
 	// Note: we do custom SDK validation because the validateCorrectSDK method does a lot more than we need
 	sdk = cli.tiapp['sdk-version'] || Object.keys(cli.env.sdks).sort().reverse()[0];


### PR DESCRIPTION
in 3.2.0 was getting 

```
/Users/dbankier/.nvm/v0.10.22/lib/node_modules/titanium/node_modules/longjohn/dist/longjohn.js:184
        throw e;
              ^
TypeError: Cannot read property 'id' of undefined
    at exports.validateTiappXml (/Users/dbankier/Library/Application Support/Titanium/mobilesdk/osx/3.2.0.GA/node_modules/titani
um-sdk/lib/titanium.js:141:12)
    at validateCLIParameters (/Users/dbankier/Titanium-Projects/Tools/titanium-code-processor/commands/analyze.js:427:5)
```
