### PR TITLE
prevent accidental npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
 	},
 	"engine": {
 		"node": ">=0.8"
-	}
+	},
+	"private": true
 }


### PR DESCRIPTION
Added `”private”:true`, which prevents publishing to npm accidentally via [npm "private"](https://npmjs.org/doc/json.html#private)
